### PR TITLE
Updated print to () format for 3.6.

### DIFF
--- a/shell_helper/shellhelper.py
+++ b/shell_helper/shellhelper.py
@@ -266,7 +266,7 @@ class ShellHelper(object):
 
 
 def __callback_test(text):
-    print '*' + text
+    print('*' + text)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This will let shell_helper compile with the latest python 3.6 installation.